### PR TITLE
Update interfaceCanvas.js

### DIFF
--- a/gui/interfaceCanvas.js
+++ b/gui/interfaceCanvas.js
@@ -766,7 +766,9 @@ export class KonvaIText extends Konva.Shape {
       // This code removes any formatting from the pasted text.
       inputElem.oninput = () => {
         // eslint-disable-next-line no-self-assign
+        const index = getInputCursorIndex();
         inputElem.textContent = inputElem.textContent;
+        setCursor(index);
       };
     }
 


### PR DESCRIPTION
Found a bug from commit aea402942003e3d13cf38c37830e7434add4d852 where editing a word moves the cursor back to the start of the word.